### PR TITLE
fix(config): disable observability in wrangler.jsonc

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -10,7 +10,7 @@
 
   // Observability for debugging
   "observability": {
-    "enabled": true
+    "enabled": false
   },
 
   // Service binding to worker-logs for centralized logging


### PR DESCRIPTION
CloudFlare observability is redundant since we use worker-logs for logging. Fixes #6