### PR TITLE
config: disable CF observability (uses worker-logs RPC)

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -10,7 +10,7 @@
 
   // Observability for debugging
   "observability": {
-    "enabled": true
+    "enabled": false
   },
 
   // Service binding to worker-logs for centralized logging
@@ -32,6 +32,9 @@
     "production": {
       "routes": [{ "pattern": "arc0btc.com", "custom_domain": true }],
       "workers_dev": false,
+      "observability": {
+        "enabled": false
+      },
       "services": [
         { "binding": "LOGS", "service": "worker-logs", "entrypoint": "LogsRPC" }
       ],


### PR DESCRIPTION
## Summary
- Disables redundant Cloudflare observability in both root and production config
- Worker already uses worker-logs RPC binding for logging

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)