### PR TITLE
config: disable observability in favor of worker-logs

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,9 +8,9 @@
   // Default: deploys to arc0btc-worker.stacklets.workers.dev (preview)
   "workers_dev": true,
 
-  // Observability for debugging
+  // Observability disabled — logging handled via worker-logs RPC binding
   "observability": {
-    "enabled": true
+    "enabled": false
   },
 
   // Service binding to worker-logs for centralized logging
@@ -32,6 +32,9 @@
     "production": {
       "routes": [{ "pattern": "arc0btc.com", "custom_domain": true }],
       "workers_dev": false,
+      "observability": {
+        "enabled": false
+      },
       "services": [
         { "binding": "LOGS", "service": "worker-logs", "entrypoint": "LogsRPC" }
       ],


### PR DESCRIPTION
## Summary
- Disables Cloudflare observability (`enabled: false`) in both root and production environments
- Logging is already handled via the `worker-logs` RPC service binding, making built-in observability redundant

Closes #6

## Test plan
- [ ] Verify wrangler.jsonc is valid JSON with comments
- [ ] Deploy and confirm worker-logs still receives logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)