### PR TITLE
fix: disable CF observability (worker-logs handles logging)

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,9 +8,9 @@
   // Default: deploys to arc0btc-worker.stacklets.workers.dev (preview)
   "workers_dev": true,
 
-  // Observability for debugging
+  // Observability disabled: worker uses worker-logs via RPC binding (LOGS service)
   "observability": {
-    "enabled": true
+    "enabled": false
   },
 
   // Service binding to worker-logs for centralized logging
@@ -32,6 +32,9 @@
     "production": {
       "routes": [{ "pattern": "arc0btc.com", "custom_domain": true }],
       "workers_dev": false,
+      "observability": {
+        "enabled": false
+      },
       "services": [
         { "binding": "LOGS", "service": "worker-logs", "entrypoint": "LogsRPC" }
       ],


### PR DESCRIPTION
## Summary

Closes #6

- Set `"observability": { "enabled": false }` in root config (was `true`)
- Added explicit `"observability": { "enabled": false }` in `env.production` for consistency

## Context

Cloudflare's built-in observability is redundant for this worker since the `worker-logs` RPC binding (`LogsRPC`) already handles all logging. This is consistent with `aibtcdev/landing-page`, which has no observability set and relies on its worker-logs service binding.

## Test plan

- [ ] Deploy to preview (`wrangler deploy`) and verify worker functions normally
- [ ] Deploy to production (`wrangler deploy --env production`) and verify worker functions normally
- [ ] Confirm logs still appear via worker-logs binding

🤖 Generated with [Claude Code](https://claude.com/claude-code)