### PR TITLE
refactor: deduplicate feed handlers into single parameterized function

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -302,127 +302,53 @@ export async function handleFeed(c: Context): Promise<Response> {
 }
 
 /**
- * Handle upstream feed endpoint (GitHub activity)
+ * Factory function for individual feed handlers.
+ * Consolidates the shared logic of handleFeedUpstream, handleFeedTrends,
+ * and handleFeedArxiv into a single parameterized implementation.
  */
-export async function handleFeedUpstream(c: Context): Promise<Response> {
-  const kv = (c.env as { FEEDS_KV?: KVNamespace })?.FEEDS_KV;
-  if (!kv) {
-    return c.json({ error: "Feed service not configured" }, 503);
-  }
-
-  try {
-    const data = await kv.get("feed:upstream");
-
-    if (!data) {
-      return c.json({ error: "Feed not found" }, 404);
+function createFeedHandler(kvKey: string, title: string) {
+  return async (c: Context): Promise<Response> => {
+    const kv = (c.env as { FEEDS_KV?: KVNamespace })?.FEEDS_KV;
+    if (!kv) {
+      return c.json({ error: "Feed service not configured" }, 503);
     }
 
-    const agent = detectAgent(
-      c.req.header("user-agent") || "",
-      c.req.header("accept") || ""
-    );
+    try {
+      const data = await kv.get(kvKey);
 
-    if (agent.preferredFormat === "json") {
-      return c.json({
-        source: "upstream",
-        content: data,
-        format: "markdown",
-        timestamp: new Date().toISOString(),
-      });
-    } else if (agent.preferredFormat === "markdown") {
-      return c.text(data, 200, {
-        "Content-Type": "text/markdown",
-      });
-    } else {
-      return c.html(renderFeedPage("Upstream Activity", data));
+      if (!data) {
+        return c.json({ error: "Feed not found" }, 404);
+      }
+
+      const agent = detectAgent(
+        c.req.header("user-agent") || "",
+        c.req.header("accept") || ""
+      );
+
+      if (agent.preferredFormat === "json") {
+        return c.json({
+          source: kvKey.replace("feed:", ""),
+          content: data,
+          format: "markdown",
+          timestamp: new Date().toISOString(),
+        });
+      } else if (agent.preferredFormat === "markdown") {
+        return c.text(data, 200, {
+          "Content-Type": "text/markdown",
+        });
+      } else {
+        return c.html(renderFeedPage(title, data));
+      }
+    } catch (error) {
+      console.error(`[${kvKey}] Error fetching feed:`, error);
+      return c.json({ error: "Failed to fetch feed data" }, 500);
     }
-  } catch (error) {
-    console.error("[feed:upstream] Error fetching feed:", error);
-    return c.json({ error: "Failed to fetch feed data" }, 500);
-  }
+  };
 }
 
-/**
- * Handle trends feed endpoint (X activity)
- */
-export async function handleFeedTrends(c: Context): Promise<Response> {
-  const kv = (c.env as { FEEDS_KV?: KVNamespace })?.FEEDS_KV;
-  if (!kv) {
-    return c.json({ error: "Feed service not configured" }, 503);
-  }
-
-  try {
-    const data = await kv.get("feed:trends");
-
-    if (!data) {
-      return c.json({ error: "Feed not found" }, 404);
-    }
-
-    const agent = detectAgent(
-      c.req.header("user-agent") || "",
-      c.req.header("accept") || ""
-    );
-
-    if (agent.preferredFormat === "json") {
-      return c.json({
-        source: "trends",
-        content: data,
-        format: "markdown",
-        timestamp: new Date().toISOString(),
-      });
-    } else if (agent.preferredFormat === "markdown") {
-      return c.text(data, 200, {
-        "Content-Type": "text/markdown",
-      });
-    } else {
-      return c.html(renderFeedPage("Ecosystem Trends", data));
-    }
-  } catch (error) {
-    console.error("[feed:trends] Error fetching feed:", error);
-    return c.json({ error: "Failed to fetch feed data" }, 500);
-  }
-}
-
-/**
- * Handle arxiv feed endpoint (Research papers)
- */
-export async function handleFeedArxiv(c: Context): Promise<Response> {
-  const kv = (c.env as { FEEDS_KV?: KVNamespace })?.FEEDS_KV;
-  if (!kv) {
-    return c.json({ error: "Feed service not configured" }, 503);
-  }
-
-  try {
-    const data = await kv.get("feed:arxiv");
-
-    if (!data) {
-      return c.json({ error: "Feed not found" }, 404);
-    }
-
-    const agent = detectAgent(
-      c.req.header("user-agent") || "",
-      c.req.header("accept") || ""
-    );
-
-    if (agent.preferredFormat === "json") {
-      return c.json({
-        source: "arxiv",
-        content: data,
-        format: "markdown",
-        timestamp: new Date().toISOString(),
-      });
-    } else if (agent.preferredFormat === "markdown") {
-      return c.text(data, 200, {
-        "Content-Type": "text/markdown",
-      });
-    } else {
-      return c.html(renderFeedPage("Research Papers", data));
-    }
-  } catch (error) {
-    console.error("[feed:arxiv] Error fetching feed:", error);
-    return c.json({ error: "Failed to fetch feed data" }, 500);
-  }
-}
+export const handleFeedUpstream = createFeedHandler("feed:upstream", "Upstream Activity");
+export const handleFeedTrends = createFeedHandler("feed:trends", "Ecosystem Trends");
+export const handleFeedArxiv = createFeedHandler("feed:arxiv", "Research Papers");
 
 // =============================================================================
 // Agent Card Handler


### PR DESCRIPTION
## Summary
- Consolidates duplicate feed handler functions (handleFeedUpstream, handleFeedTrends, handleFeedArxiv) into a single parameterized `createFeedHandler()` helper
- Reduces ~90 lines of duplicate code while maintaining identical behavior

Closes #4

## Test plan
- [ ] Verify each feed endpoint returns identical responses as before
- [ ] Confirm handler routing still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)