### PR TITLE
refactor: deduplicate feed handlers into createFeedHandler factory

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -302,127 +302,54 @@ export async function handleFeed(c: Context): Promise<Response> {
 }
 
 /**
- * Handle upstream feed endpoint (GitHub activity)
+ * Factory function that creates a feed handler for a given KV key and title.
+ * Replaces the formerly duplicated handleFeedUpstream, handleFeedTrends, and
+ * handleFeedArxiv functions with a single parameterized implementation.
  */
-export async function handleFeedUpstream(c: Context): Promise<Response> {
-  const kv = (c.env as { FEEDS_KV?: KVNamespace })?.FEEDS_KV;
-  if (!kv) {
-    return c.json({ error: "Feed service not configured" }, 503);
-  }
-
-  try {
-    const data = await kv.get("feed:upstream");
-
-    if (!data) {
-      return c.json({ error: "Feed not found" }, 404);
+function createFeedHandler(kvKey: string, title: string) {
+  const source = kvKey.replace("feed:", "");
+  return async function (c: Context): Promise<Response> {
+    const kv = (c.env as { FEEDS_KV?: KVNamespace })?.FEEDS_KV;
+    if (!kv) {
+      return c.json({ error: "Feed service not configured" }, 503);
     }
 
-    const agent = detectAgent(
-      c.req.header("user-agent") || "",
-      c.req.header("accept") || ""
-    );
+    try {
+      const data = await kv.get(kvKey);
 
-    if (agent.preferredFormat === "json") {
-      return c.json({
-        source: "upstream",
-        content: data,
-        format: "markdown",
-        timestamp: new Date().toISOString(),
-      });
-    } else if (agent.preferredFormat === "markdown") {
-      return c.text(data, 200, {
-        "Content-Type": "text/markdown",
-      });
-    } else {
-      return c.html(renderFeedPage("Upstream Activity", data));
+      if (!data) {
+        return c.json({ error: "Feed not found" }, 404);
+      }
+
+      const agent = detectAgent(
+        c.req.header("user-agent") || "",
+        c.req.header("accept") || ""
+      );
+
+      if (agent.preferredFormat === "json") {
+        return c.json({
+          source,
+          content: data,
+          format: "markdown",
+          timestamp: new Date().toISOString(),
+        });
+      } else if (agent.preferredFormat === "markdown") {
+        return c.text(data, 200, {
+          "Content-Type": "text/markdown",
+        });
+      } else {
+        return c.html(renderFeedPage(title, data));
+      }
+    } catch (error) {
+      console.error(`[${kvKey}] Error fetching feed:`, error);
+      return c.json({ error: "Failed to fetch feed data" }, 500);
     }
-  } catch (error) {
-    console.error("[feed:upstream] Error fetching feed:", error);
-    return c.json({ error: "Failed to fetch feed data" }, 500);
-  }
+  };
 }
 
-/**
- * Handle trends feed endpoint (X activity)
- */
-export async function handleFeedTrends(c: Context): Promise<Response> {
-  const kv = (c.env as { FEEDS_KV?: KVNamespace })?.FEEDS_KV;
-  if (!kv) {
-    return c.json({ error: "Feed service not configured" }, 503);
-  }
-
-  try {
-    const data = await kv.get("feed:trends");
-
-    if (!data) {
-      return c.json({ error: "Feed not found" }, 404);
-    }
-
-    const agent = detectAgent(
-      c.req.header("user-agent") || "",
-      c.req.header("accept") || ""
-    );
-
-    if (agent.preferredFormat === "json") {
-      return c.json({
-        source: "trends",
-        content: data,
-        format: "markdown",
-        timestamp: new Date().toISOString(),
-      });
-    } else if (agent.preferredFormat === "markdown") {
-      return c.text(data, 200, {
-        "Content-Type": "text/markdown",
-      });
-    } else {
-      return c.html(renderFeedPage("Ecosystem Trends", data));
-    }
-  } catch (error) {
-    console.error("[feed:trends] Error fetching feed:", error);
-    return c.json({ error: "Failed to fetch feed data" }, 500);
-  }
-}
-
-/**
- * Handle arxiv feed endpoint (Research papers)
- */
-export async function handleFeedArxiv(c: Context): Promise<Response> {
-  const kv = (c.env as { FEEDS_KV?: KVNamespace })?.FEEDS_KV;
-  if (!kv) {
-    return c.json({ error: "Feed service not configured" }, 503);
-  }
-
-  try {
-    const data = await kv.get("feed:arxiv");
-
-    if (!data) {
-      return c.json({ error: "Feed not found" }, 404);
-    }
-
-    const agent = detectAgent(
-      c.req.header("user-agent") || "",
-      c.req.header("accept") || ""
-    );
-
-    if (agent.preferredFormat === "json") {
-      return c.json({
-        source: "arxiv",
-        content: data,
-        format: "markdown",
-        timestamp: new Date().toISOString(),
-      });
-    } else if (agent.preferredFormat === "markdown") {
-      return c.text(data, 200, {
-        "Content-Type": "text/markdown",
-      });
-    } else {
-      return c.html(renderFeedPage("Research Papers", data));
-    }
-  } catch (error) {
-    console.error("[feed:arxiv] Error fetching feed:", error);
-    return c.json({ error: "Failed to fetch feed data" }, 500);
-  }
-}
+export const handleFeedUpstream = createFeedHandler("feed:upstream", "Upstream Activity");
+export const handleFeedTrends = createFeedHandler("feed:trends", "Ecosystem Trends");
+export const handleFeedArxiv = createFeedHandler("feed:arxiv", "Research Papers");
 
 // =============================================================================
 // Agent Card Handler


### PR DESCRIPTION
## Summary
- Extracts shared logic from `handleFeedUpstream`, `handleFeedTrends`, and `handleFeedArxiv` into a single `createFeedHandler(kvKey, title)` factory function
- Reduces ~115 lines of duplicated code to ~42 lines (net -73 lines)
- Each exported handler is now a one-liner calling the factory with its specific KV key and display title
- Preserves all existing behavior: 503 on missing KV binding, 404 on missing data, `detectAgent()` content negotiation, JSON/markdown/HTML response paths, and error logging

Closes #4

## Verification
- `tsc --noEmit` passes with zero errors
- All 9 existing tests pass (`npm test`)

## Test plan
- [ ] Verify `GET /api/feed/upstream` returns identical JSON, markdown, and HTML responses
- [ ] Verify `GET /api/feed/trends` returns identical JSON, markdown, and HTML responses
- [ ] Verify `GET /api/feed/arxiv` returns identical JSON, markdown, and HTML responses
- [ ] Verify each endpoint returns 404 when the KV key is missing
- [ ] Verify 503 when FEEDS_KV binding is not configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)