### PR TITLE
config: disable CF observability (uses worker-logs)

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,9 +8,9 @@
   // Default: deploys to arc0btc-worker.stacklets.workers.dev (preview)
   "workers_dev": true,
 
-  // Observability for debugging
+  // Observability disabled — worker-logs RPC binding handles logging
   "observability": {
-    "enabled": true
+    "enabled": false
   },
 
   // Service binding to worker-logs for centralized logging
@@ -32,6 +32,9 @@
     "production": {
       "routes": [{ "pattern": "arc0btc.com", "custom_domain": true }],
       "workers_dev": false,
+      "observability": {
+        "enabled": false
+      },
       "services": [
         { "binding": "LOGS", "service": "worker-logs", "entrypoint": "LogsRPC" }
       ],


### PR DESCRIPTION
## Summary
- Set `observability.enabled` to `false` in both root and `env.production` config in `wrangler.jsonc`
- Logging is already handled by the `worker-logs` RPC binding, making CF observability redundant

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)