### PR TITLE
refactor: deduplicate feed handlers into factory function

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -302,127 +302,69 @@ export async function handleFeed(c: Context): Promise<Response> {
 }
 
 /**
- * Handle upstream feed endpoint (GitHub activity)
+ * Factory that creates a feed handler for a specific KV key, source, and title.
+ * Eliminates the repetition across handleFeedUpstream, handleFeedTrends, and handleFeedArxiv.
  */
-export async function handleFeedUpstream(c: Context): Promise<Response> {
-  const kv = (c.env as { FEEDS_KV?: KVNamespace })?.FEEDS_KV;
-  if (!kv) {
-    return c.json({ error: "Feed service not configured" }, 503);
-  }
-
-  try {
-    const data = await kv.get("feed:upstream");
-
-    if (!data) {
-      return c.json({ error: "Feed not found" }, 404);
+function createFeedHandler(kvKey: string, source: string, title: string) {
+  return async (c: Context): Promise<Response> => {
+    const kv = (c.env as { FEEDS_KV?: KVNamespace })?.FEEDS_KV;
+    if (!kv) {
+      return c.json({ error: "Feed service not configured" }, 503);
     }
 
-    const agent = detectAgent(
-      c.req.header("user-agent") || "",
-      c.req.header("accept") || ""
-    );
+    try {
+      const data = await kv.get(kvKey);
 
-    if (agent.preferredFormat === "json") {
-      return c.json({
-        source: "upstream",
-        content: data,
-        format: "markdown",
-        timestamp: new Date().toISOString(),
-      });
-    } else if (agent.preferredFormat === "markdown") {
-      return c.text(data, 200, {
-        "Content-Type": "text/markdown",
-      });
-    } else {
-      return c.html(renderFeedPage("Upstream Activity", data));
+      if (!data) {
+        return c.json({ error: "Feed not found" }, 404);
+      }
+
+      const agent = detectAgent(
+        c.req.header("user-agent") || "",
+        c.req.header("accept") || ""
+      );
+
+      if (agent.preferredFormat === "json") {
+        return c.json({
+          source,
+          content: data,
+          format: "markdown",
+          timestamp: new Date().toISOString(),
+        });
+      } else if (agent.preferredFormat === "markdown") {
+        return c.text(data, 200, {
+          "Content-Type": "text/markdown",
+        });
+      } else {
+        return c.html(renderFeedPage(title, data));
+      }
+    } catch (error) {
+      console.error(`[feed:${source}] Error fetching feed:`, error);
+      return c.json({ error: "Failed to fetch feed data" }, 500);
     }
-  } catch (error) {
-    console.error("[feed:upstream] Error fetching feed:", error);
-    return c.json({ error: "Failed to fetch feed data" }, 500);
-  }
+  };
 }
 
-/**
- * Handle trends feed endpoint (X activity)
- */
-export async function handleFeedTrends(c: Context): Promise<Response> {
-  const kv = (c.env as { FEEDS_KV?: KVNamespace })?.FEEDS_KV;
-  if (!kv) {
-    return c.json({ error: "Feed service not configured" }, 503);
-  }
+/** Handle upstream feed endpoint (GitHub activity) */
+export const handleFeedUpstream = createFeedHandler(
+  "feed:upstream",
+  "upstream",
+  "Upstream Activity"
+);
 
-  try {
-    const data = await kv.get("feed:trends");
+/** Handle trends feed endpoint (X activity) */
+export const handleFeedTrends = createFeedHandler(
+  "feed:trends",
+  "trends",
+  "Ecosystem Trends"
+);
 
-    if (!data) {
-      return c.json({ error: "Feed not found" }, 404);
-    }
-
-    const agent = detectAgent(
-      c.req.header("user-agent") || "",
-      c.req.header("accept") || ""
-    );
-
-    if (agent.preferredFormat === "json") {
-      return c.json({
-        source: "trends",
-        content: data,
-        format: "markdown",
-        timestamp: new Date().toISOString(),
-      });
-    } else if (agent.preferredFormat === "markdown") {
-      return c.text(data, 200, {
-        "Content-Type": "text/markdown",
-      });
-    } else {
-      return c.html(renderFeedPage("Ecosystem Trends", data));
-    }
-  } catch (error) {
-    console.error("[feed:trends] Error fetching feed:", error);
-    return c.json({ error: "Failed to fetch feed data" }, 500);
-  }
-}
-
-/**
- * Handle arxiv feed endpoint (Research papers)
- */
-export async function handleFeedArxiv(c: Context): Promise<Response> {
-  const kv = (c.env as { FEEDS_KV?: KVNamespace })?.FEEDS_KV;
-  if (!kv) {
-    return c.json({ error: "Feed service not configured" }, 503);
-  }
-
-  try {
-    const data = await kv.get("feed:arxiv");
-
-    if (!data) {
-      return c.json({ error: "Feed not found" }, 404);
-    }
-
-    const agent = detectAgent(
-      c.req.header("user-agent") || "",
-      c.req.header("accept") || ""
-    );
-
-    if (agent.preferredFormat === "json") {
-      return c.json({
-        source: "arxiv",
-        content: data,
-        format: "markdown",
-        timestamp: new Date().toISOString(),
-      });
-    } else if (agent.preferredFormat === "markdown") {
-      return c.text(data, 200, {
-        "Content-Type": "text/markdown",
-      });
-    } else {
-      return c.html(renderFeedPage("Research Papers", data));
-    }
-  } catch (error) {
-    console.error("[feed:arxiv] Error fetching feed:", error);
-    return c.json({ error: "Failed to fetch feed data" }, 500);
-  }
-}
+/** Handle arxiv feed endpoint (Research papers) */
+export const handleFeedArxiv = createFeedHandler(
+  "feed:arxiv",
+  "arxiv",
+  "Research Papers"
+);
 
 // =============================================================================
 // Agent Card Handler


### PR DESCRIPTION
Closes #4

## Summary

Three feed handler functions (`handleFeedUpstream`, `handleFeedTrends`, `handleFeedArxiv`) shared ~90 lines of identical logic — same KV lookup, same 503/404 guards, same content-negotiation block, same error catch. Any bug fix or behaviour change had to be applied three times.

This PR introduces a `createFeedHandler(kvKey, source, title)` factory that encapsulates the shared logic once. The three exports are now one-liners that delegate to the factory.

## Changes

- `src/handlers.ts`: replace three duplicate `async function` exports with a private `createFeedHandler` factory + three `export const` declarations
- No changes to `src/index.ts` — exported names are identical
- All 9 existing tests pass unchanged

## Test plan

- [x] `npx vitest run` — 9/9 tests pass
- [x] Exported symbols `handleFeedUpstream`, `handleFeedTrends`, `handleFeedArxiv` unchanged (no changes needed in index.ts)
- [x] Error log prefix still uses the per-source string (e.g. `[feed:upstream]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)