### PR TITLE
fix(x402): update payment headers to v2 spec

### DIFF
--- a/src/client/components/Services.tsx
+++ b/src/client/components/Services.tsx
@@ -243,10 +243,22 @@ function AskArcForm({ wallet }: { wallet: WalletState }) {
         "Content-Type": "application/json",
       };
 
-      // Include x402 payment header if wallet connected
+      // Include x402 v2 payment-signature header if wallet connected
       if (wallet.connected && wallet.address) {
-        // Placeholder payment header — real payment flow requires Stacks tx
-        headers["x-402-payment"] = `stx:${wallet.address}:0000000000000000000000000000000000000000000000000000000000000000:0.005:STX`;
+        // Placeholder payment — real flow requires signed sBTC transfer
+        const paymentPayload = {
+          x402Version: 2,
+          payload: { transaction: "0x" + "0".repeat(64) },
+          accepted: {
+            scheme: "exact",
+            network: "stacks:1",
+            amount: "250",
+            asset: "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token",
+            payTo: "SP2GHQRCRMYY4S8PMBR49BEKX144VR437YT42SF3B",
+            maxTimeoutSeconds: 300,
+          },
+        };
+        headers["payment-signature"] = btoa(JSON.stringify(paymentPayload));
       }
 
       const response = await fetch("/api/ask-arc", {
@@ -310,7 +322,7 @@ function AskArcForm({ wallet }: { wallet: WalletState }) {
         onClick={handleSubmit}
         disabled={loading || !question.trim()}
       >
-        {loading ? "Querying..." : "Ask Arc (0.005 STX)"}
+        {loading ? "Querying..." : "Ask Arc (250 sats)"}
       </button>
 
       {error && <div className="form-error">{error}</div>}
@@ -507,10 +519,25 @@ export function Services({ wallet }: ServicesProps) {
           — HTTP 402 Payment Required with on-chain settlement. Connect your Stacks wallet above to
           interact directly, or integrate programmatically:
         </p>
-        <pre className="svc-code">{`curl -X POST https://arc0btc.com/api/ask-arc \\
+        <pre className="svc-code">{`# Step 1: Probe endpoint — returns 402 with payment-required header
+curl -X POST https://arc0btc.com/api/ask-arc \\
   -H "Content-Type: application/json" \\
-  -H "x-402-payment: stx:{address}:{txid}:{amount}:STX" \\
-  -d '{"question": "What is x402?"}'`}</pre>
+  -d '{"question": "What is x402?"}'
+# → HTTP 402 + payment-required: <base64 PaymentRequiredV2>
+
+# Step 2: Decode requirements, sign sBTC transfer, retry with payment
+curl -X POST https://arc0btc.com/api/ask-arc \\
+  -H "Content-Type: application/json" \\
+  -H "payment-signature: <base64 PaymentPayloadV2>" \\
+  -d '{"question": "What is x402?"}'
+# → HTTP 200 + payment-response: <base64 settlement result>`}</pre>
+        <p style={{ fontSize: "0.85rem", opacity: 0.75, marginTop: "0.5rem" }}>
+          x402 v2 headers: <code>payment-required</code> (402 response),{" "}
+          <code>payment-signature</code> (payment request),{" "}
+          <code>payment-response</code> (settlement confirmation).
+          Relay: <a href="https://x402-relay.aibtc.com" target="_blank" rel="noopener noreferrer">x402-relay.aibtc.com</a>.
+          Discovery: <a href="/.well-known/x402"><code>/.well-known/x402</code></a>.
+        </p>
         <p className="meta">
           Agent card:{" "}
           <a href="/.well-known/agent.json">

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -4,115 +4,52 @@
 
 import type { Context } from "hono";
 import { findAnswer } from "./knowledge";
-
-// =============================================================================
-// x402 Payment Verification (Stubbed for Phase 1)
-// =============================================================================
-
-/**
- * Check for x402 payment header and verify payment
- *
- * Phase 2: Parses x-402-payment header and validates format
- * Format: stx:{address}:{txid}:{amount}:{token}
- *
- * Note: Phase 2 trusts the header (no on-chain verification yet)
- * Future: Add on-chain tx verification via Stacks API
- */
-function verifyX402Payment(c: Context): {
-  verified: boolean;
-  callerAddress?: string;
-  amount?: number;
-  token?: string;
-  error?: string;
-} {
-  const paymentHeader = c.req.header("x-402-payment");
-
-  if (!paymentHeader) {
-    // No payment header - return payment required
-    return {
-      verified: false,
-      error: "Payment required",
-    };
-  }
-
-  console.log("[x402] Payment header present:", paymentHeader);
-
-  // Parse header format: stx:{address}:{txid}:{amount}:{token}
-  const parts = paymentHeader.split(":");
-
-  if (parts.length < 5 || parts[0] !== "stx") {
-    console.log("[x402] Invalid header format:", paymentHeader);
-    return {
-      verified: false,
-      error: "Invalid payment header format (expected: stx:address:txid:amount:token)",
-    };
-  }
-
-  const [, address, txid, amountStr, token] = parts;
-
-  // Validate address (basic check: starts with SP or SM, 41 chars)
-  if (!address.match(/^S[PM][0-9A-Z]{39}$/)) {
-    console.log("[x402] Invalid Stacks address:", address);
-    return {
-      verified: false,
-      error: "Invalid Stacks address in payment header",
-    };
-  }
-
-  // Validate txid (64 hex chars with optional 0x prefix)
-  const cleanTxid = txid.startsWith("0x") ? txid.slice(2) : txid;
-  if (!cleanTxid.match(/^[0-9a-f]{64}$/i)) {
-    console.log("[x402] Invalid transaction ID:", txid);
-    return {
-      verified: false,
-      error: "Invalid transaction ID in payment header",
-    };
-  }
-
-  // Validate amount (must be positive number)
-  const amount = parseFloat(amountStr);
-  if (isNaN(amount) || amount <= 0) {
-    console.log("[x402] Invalid amount:", amountStr);
-    return {
-      verified: false,
-      error: "Invalid amount in payment header",
-    };
-  }
-
-  if (!token) {
-    console.log("[x402] Invalid token:", token);
-    return {
-      verified: false,
-      error: "Invalid token in payment header",
-    };
-  }
-
-  console.log(
-    `[x402] Payment verified: ${amount} ${token} from ${address} (tx: ${cleanTxid})`
-  );
-
-  return {
-    verified: true,
-    callerAddress: address,
-    amount,
-    token,
-  };
-}
+import { buildPaymentRequired, verifyPayment } from "./lib/x402";
 
 // =============================================================================
 // Ask Arc Handler
 // =============================================================================
 
 export async function handleAskArc(c: Context): Promise<Response> {
-  const payment = verifyX402Payment(c);
+  const PRICE_SATS = 250; // Quick tier default
 
-  if (!payment.verified) {
-    return c.json(
-      {
+  const paymentHeader = c.req.header("payment-signature");
+
+  if (!paymentHeader) {
+    const paymentRequired = buildPaymentRequired(
+      `${new URL(c.req.url).origin}/api/ask-arc`,
+      PRICE_SATS,
+      "Ask Arc — knowledge base query"
+    );
+
+    return new Response(
+      JSON.stringify({
         error: "Payment required",
         code: "PAYMENT_REQUIRED",
-        cost: 0.005,
-        token: "STX",
+        pricing: {
+          quick: { amount: 250, unit: "sats (sBTC)", model: "Haiku" },
+          research: { amount: 2500, unit: "sats (sBTC)", model: "Sonnet" },
+          deep: { amount: 10000, unit: "sats (sBTC)", model: "Opus" },
+        },
+      }),
+      {
+        status: 402,
+        headers: {
+          "Content-Type": "application/json",
+          "payment-required": paymentRequired.headers.get("payment-required") || "",
+        },
+      }
+    );
+  }
+
+  const payment = await verifyPayment(paymentHeader, PRICE_SATS);
+
+  if (!payment.success) {
+    return c.json(
+      {
+        error: "Payment verification failed",
+        code: "PAYMENT_FAILED",
+        detail: payment.error,
       },
       402
     );
@@ -212,11 +149,26 @@ export async function handleAskArc(c: Context): Promise<Response> {
       `[ask-arc] Query processed in ${responseTime}ms: "${question.slice(0, 50)}..." -> confidence: ${result.confidence}`
     );
 
-    return c.json({
-      answer: result.answer,
-      sources: result.sources,
-      confidence: result.confidence,
-    });
+    return new Response(
+      JSON.stringify({
+        answer: result.answer,
+        sources: result.sources,
+        confidence: result.confidence,
+      }),
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          "payment-response": btoa(
+            JSON.stringify({
+              success: true,
+              payer: payment.payer,
+              transaction: payment.txid,
+            })
+          ),
+        },
+      }
+    );
   } catch (error) {
     console.error("[ask-arc] Error processing query:", error);
 

--- a/src/pages/landing.ts
+++ b/src/pages/landing.ts
@@ -324,26 +324,33 @@ curl https://arc0btc.com/ <span class="method">\</span>
 }
       </div>
 
-      <h3 style="color: #ffffff; margin-top: 1.5rem; margin-bottom: 0.75rem; font-size: 1rem;">Ask Arc API</h3>
+      <h3 style="color: #ffffff; margin-top: 1.5rem; margin-bottom: 0.75rem; font-size: 1rem;">Ask Arc API (x402 v2)</h3>
       <p>Query my knowledge base. Categories: <code>clarity</code>, <code>stacks</code>, <code>agent-setup</code>, <code>ecosystem</code>.</p>
 
       <div class="code-block">
-<span class="comment"># Question with category filter</span>
+<span class="comment"># Step 1: Probe — returns 402 + payment-required header</span>
 curl -X POST https://arc0btc.com/api/ask-arc <span class="method">\</span>
   -H <span class="string">"Content-Type: application/json"</span> <span class="method">\</span>
-  -H <span class="string">"x-402-payment: stx:{address}:{txid}:0.005:STX"</span> <span class="method">\</span>
-  -d '{
-    <span class="key">"question"</span>: <span class="string">"tx-sender vs contract-caller: when does it matter?"</span>,
-    <span class="key">"category"</span>: <span class="string">"clarity"</span>
-  }'
+  -d '{<span class="key">"question"</span>: <span class="string">"tx-sender vs contract-caller?"</span>}'
+<span class="comment"># &rarr; 402 + payment-required: &lt;base64 PaymentRequiredV2&gt;</span>
 
-<span class="comment"># Response</span>
+<span class="comment"># Step 2: Sign sBTC transfer, retry with payment-signature</span>
+curl -X POST https://arc0btc.com/api/ask-arc <span class="method">\</span>
+  -H <span class="string">"Content-Type: application/json"</span> <span class="method">\</span>
+  -H <span class="string">"payment-signature: &lt;base64 PaymentPayloadV2&gt;"</span> <span class="method">\</span>
+  -d '{<span class="key">"question"</span>: <span class="string">"tx-sender vs contract-caller?"</span>}'
+
+<span class="comment"># Response (200 + payment-response header)</span>
 {
   <span class="key">"answer"</span>: <span class="string">"In Clarity contracts, tx-sender is the originating wallet..."</span>,
   <span class="key">"sources"</span>: [<span class="string">"clarity-reference.md"</span>],
   <span class="key">"confidence"</span>: <span class="string">"high"</span>
 }
       </div>
+      <p style="font-size: 0.85rem; color: #E9D4CF; opacity: 0.65; margin-top: 0.5rem;">
+        Headers: <code>payment-required</code> (402), <code>payment-signature</code> (request), <code>payment-response</code> (200).
+        Relay: x402-relay.aibtc.com. Discovery: <a href="/.well-known/x402"><code>/.well-known/x402</code></a>.
+      </p>
     </section>
 
     <section>


### PR DESCRIPTION
## Summary

- Migrates Ask Arc endpoint (`/api/ask-arc`) from legacy `x-402-payment` header format to x402 v2 spec
- Updates `handlers.ts` to use `lib/x402.ts` (same pattern as research routes) — returns `payment-required` header on 402, accepts `payment-signature`, returns `payment-response` on 200
- Fixes Services page curl example and interactive form to show correct v2 two-step flow (probe → pay)
- Updates landing page fallback with correct v2 header names and relay discovery link

**Before:** `x-402-payment: stx:{address}:{txid}:{amount}:STX` (custom, non-standard)
**After:** `payment-required` / `payment-signature` / `payment-response` (x402 v2 standard, base64-encoded JSON payloads, relay settlement via x402-relay.aibtc.com)

## Test plan

- [ ] Verify `POST /api/ask-arc` without payment returns 402 with `payment-required` header
- [ ] Verify `payment-required` header decodes to valid `PaymentRequiredV2` JSON
- [ ] Verify `POST /api/ask-arc` with valid `payment-signature` header returns 200 + `payment-response`
- [ ] Verify Services page shows correct v2 curl example
- [ ] Verify landing page (fallback) shows correct v2 example
- [ ] Build client: `npm run build:client` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)