### PR TITLE
fix: log only non-2xx responses to worker-logs (4xx→warn, 5xx→error)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,14 +6,8 @@ import {
   handleAgentRegistration,
 } from "./handlers";
 import { detectAgent } from "./middleware/agent-detection";
+import { requestLogging, type LogsBinding } from "./middleware/request-logging";
 import { research } from "./routes/research";
-
-// worker-logs RPC binding type
-type LogsBinding = {
-  info: (appId: string, msg: string, context?: Record<string, unknown>) => Promise<void>;
-  warn: (appId: string, msg: string, context?: Record<string, unknown>) => Promise<void>;
-  error: (appId: string, msg: string, context?: Record<string, unknown>) => Promise<void>;
-};
 
 // Assets binding from wrangler config (serves built React SPA)
 type AssetsBinding = {
@@ -33,43 +27,8 @@ const app = new Hono<{ Bindings: Bindings }>();
 // Enable CORS for cross-origin requests
 app.use("*", cors());
 
-// Request logging middleware — fire-and-forget to worker-logs
-// Only emits for error responses (4xx → warn, 5xx → error).
-// 2xx/3xx are intentionally silent: CF Workers observability already captures
-// per-request analytics, so access-log noise is redundant and costs DO invocations.
-app.use("*", async (c, next) => {
-  const start = Date.now();
-  await next();
-  const status = c.res.status;
-  if (status < 400) return;
-  const logs = c.env?.LOGS;
-  if (logs) {
-    const duration = Date.now() - start;
-    const pathname = c.req.path;
-    const context = {
-      method: c.req.method,
-      path: pathname,
-      status,
-      duration_ms: duration,
-      user_agent: c.req.header("user-agent")?.slice(0, 100),
-    };
-    const logEntry = (
-      status >= 500
-        ? logs.error(APP_ID, `${c.req.method} ${pathname}`, context)
-        : logs.warn(APP_ID, `${c.req.method} ${pathname}`, context)
-    ).catch((err: unknown) => {
-      console.error("[logging] Failed to send log:", err);
-    });
-    // Use waitUntil if available to avoid blocking the response.
-    // c.executionCtx throws when no ExecutionContext is provided (e.g. in tests),
-    // so guard with try/catch rather than optional chaining on the getter itself.
-    try {
-      c.executionCtx.waitUntil(logEntry);
-    } catch {
-      // No ExecutionContext available (local dev / test) — fire-and-forget without waitUntil
-    }
-  }
-});
+// Request logging middleware — fire-and-forget to worker-logs (errors only)
+app.use("*", requestLogging(APP_ID));
 
 // Landing page — JSON for agent clients, SPA for humans (served by assets binding)
 app.get("/", (c) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ app.use("*", async (c, next) => {
   const logs = c.env?.LOGS;
   if (logs) {
     const duration = Date.now() - start;
-    const pathname = new URL(c.req.url).pathname;
+    const pathname = c.req.path;
     const context = {
       method: c.req.method,
       path: pathname,

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,24 +34,39 @@ const app = new Hono<{ Bindings: Bindings }>();
 app.use("*", cors());
 
 // Request logging middleware — fire-and-forget to worker-logs
+// Only emits for error responses (4xx → warn, 5xx → error).
+// 2xx/3xx are intentionally silent: CF Workers observability already captures
+// per-request analytics, so access-log noise is redundant and costs DO invocations.
 app.use("*", async (c, next) => {
   const start = Date.now();
   await next();
+  const status = c.res.status;
+  if (status < 400) return;
   const logs = c.env?.LOGS;
   if (logs) {
     const duration = Date.now() - start;
-    const ctx = c.executionCtx;
-    const logEntry = logs.info(APP_ID, `${c.req.method} ${new URL(c.req.url).pathname}`, {
+    const pathname = new URL(c.req.url).pathname;
+    const context = {
       method: c.req.method,
-      path: new URL(c.req.url).pathname,
-      status: c.res.status,
+      path: pathname,
+      status,
       duration_ms: duration,
       user_agent: c.req.header("user-agent")?.slice(0, 100),
-    }).catch((err: unknown) => {
+    };
+    const logEntry = (
+      status >= 500
+        ? logs.error(APP_ID, `${c.req.method} ${pathname}`, context)
+        : logs.warn(APP_ID, `${c.req.method} ${pathname}`, context)
+    ).catch((err: unknown) => {
       console.error("[logging] Failed to send log:", err);
     });
-    if (ctx?.waitUntil) {
-      ctx.waitUntil(logEntry);
+    // Use waitUntil if available to avoid blocking the response.
+    // c.executionCtx throws when no ExecutionContext is provided (e.g. in tests),
+    // so guard with try/catch rather than optional chaining on the getter itself.
+    try {
+      c.executionCtx.waitUntil(logEntry);
+    } catch {
+      // No ExecutionContext available (local dev / test) — fire-and-forget without waitUntil
     }
   }
 });

--- a/src/middleware/request-logging.ts
+++ b/src/middleware/request-logging.ts
@@ -1,0 +1,56 @@
+/**
+ * Request Logging Middleware
+ *
+ * Fire-and-forget logging to worker-logs. Only emits for error responses
+ * (4xx → warn, 5xx → error). 2xx/3xx are intentionally silent: CF Workers
+ * observability already captures per-request analytics, so access-log noise
+ * is redundant and costs AppLogsDO invocations.
+ */
+
+import type { MiddlewareHandler } from "hono";
+
+// worker-logs RPC binding type
+export type LogsBinding = {
+  info: (appId: string, msg: string, context?: Record<string, unknown>) => Promise<void>;
+  warn: (appId: string, msg: string, context?: Record<string, unknown>) => Promise<void>;
+  error: (appId: string, msg: string, context?: Record<string, unknown>) => Promise<void>;
+};
+
+/**
+ * Build the request-logging middleware for the given app id.
+ */
+export function requestLogging(
+  appId: string
+): MiddlewareHandler<{ Bindings: { LOGS?: LogsBinding } }> {
+  return async (c, next) => {
+    const start = Date.now();
+    await next();
+    const status = c.res.status;
+    if (status < 400) return;
+    const logs = c.env?.LOGS;
+    if (!logs) return;
+    const duration = Date.now() - start;
+    const pathname = c.req.path;
+    const context = {
+      method: c.req.method,
+      path: pathname,
+      status,
+      duration_ms: duration,
+      user_agent: c.req.header("user-agent")?.slice(0, 100),
+    };
+    const logEntry = (
+      status >= 500
+        ? logs.error(appId, `${c.req.method} ${pathname}`, context)
+        : logs.warn(appId, `${c.req.method} ${pathname}`, context)
+    ).catch((err: unknown) => {
+      console.error("[logging] Failed to send log:", err);
+    });
+    // c.executionCtx throws when no ExecutionContext is provided (e.g. in tests),
+    // so guard with try/catch rather than optional chaining on the getter itself.
+    try {
+      c.executionCtx.waitUntil(logEntry);
+    } catch {
+      // No ExecutionContext available (local dev / test) — fire-and-forget without waitUntil
+    }
+  };
+}

--- a/test/endpoints.test.ts
+++ b/test/endpoints.test.ts
@@ -2,7 +2,7 @@
  * Endpoint tests for arc0btc worker
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import worker from "../src/index";
 
 describe("arc0btc worker endpoints", () => {
@@ -180,18 +180,18 @@ describe("arc0btc worker endpoints", () => {
     function makeMockEnv() {
       const calls: { method: string; appId: string; msg: string; context: Record<string, unknown> }[] = [];
       const LOGS = {
-        info: vi.fn((appId: string, msg: string, context?: Record<string, unknown>) => {
+        info: (appId: string, msg: string, context?: Record<string, unknown>) => {
           calls.push({ method: "info", appId, msg, context: context ?? {} });
           return Promise.resolve();
-        }),
-        warn: vi.fn((appId: string, msg: string, context?: Record<string, unknown>) => {
+        },
+        warn: (appId: string, msg: string, context?: Record<string, unknown>) => {
           calls.push({ method: "warn", appId, msg, context: context ?? {} });
           return Promise.resolve();
-        }),
-        error: vi.fn((appId: string, msg: string, context?: Record<string, unknown>) => {
+        },
+        error: (appId: string, msg: string, context?: Record<string, unknown>) => {
           calls.push({ method: "error", appId, msg, context: context ?? {} });
           return Promise.resolve();
-        }),
+        },
       };
       return { env: { LOGS }, calls };
     }
@@ -203,9 +203,7 @@ describe("arc0btc worker endpoints", () => {
       expect(calls).toHaveLength(0);
     });
 
-    it("stays silent on a 3xx-class status (2xx route confirms status < 400 guard)", async () => {
-      // The app has no built-in redirect route; GET / returns 200.
-      // This test documents that any status < 400 is silent, using GET / as a second 2xx data point.
+    it("stays silent on another 2xx response (GET / → 200 HTML)", async () => {
       const { env, calls } = makeMockEnv();
       const req = new Request("http://localhost/");
       await worker.fetch(req, env);

--- a/test/endpoints.test.ts
+++ b/test/endpoints.test.ts
@@ -2,7 +2,7 @@
  * Endpoint tests for arc0btc worker
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import worker from "../src/index";
 
 describe("arc0btc worker endpoints", () => {
@@ -172,6 +172,75 @@ describe("arc0btc worker endpoints", () => {
       const data = await res.json();
       expect(data).toHaveProperty("answer");
       expect(data.answer).toContain("agent identity");
+    });
+  });
+
+  describe("request logging middleware", () => {
+    // Build a mock LOGS binding that records which method was called and with what args.
+    function makeMockEnv() {
+      const calls: { method: string; appId: string; msg: string; context: Record<string, unknown> }[] = [];
+      const LOGS = {
+        info: vi.fn((appId: string, msg: string, context?: Record<string, unknown>) => {
+          calls.push({ method: "info", appId, msg, context: context ?? {} });
+          return Promise.resolve();
+        }),
+        warn: vi.fn((appId: string, msg: string, context?: Record<string, unknown>) => {
+          calls.push({ method: "warn", appId, msg, context: context ?? {} });
+          return Promise.resolve();
+        }),
+        error: vi.fn((appId: string, msg: string, context?: Record<string, unknown>) => {
+          calls.push({ method: "error", appId, msg, context: context ?? {} });
+          return Promise.resolve();
+        }),
+      };
+      return { env: { LOGS }, calls };
+    }
+
+    it("stays silent on a 2xx response (GET /health → 200)", async () => {
+      const { env, calls } = makeMockEnv();
+      const req = new Request("http://localhost/health");
+      await worker.fetch(req, env);
+      expect(calls).toHaveLength(0);
+    });
+
+    it("stays silent on a 3xx-class status (2xx route confirms status < 400 guard)", async () => {
+      // The app has no built-in redirect route; GET / returns 200.
+      // This test documents that any status < 400 is silent, using GET / as a second 2xx data point.
+      const { env, calls } = makeMockEnv();
+      const req = new Request("http://localhost/");
+      await worker.fetch(req, env);
+      expect(calls).toHaveLength(0);
+    });
+
+    it("emits warn exactly once on a 4xx response (POST /api/ask-arc without payment → 402)", async () => {
+      const { env, calls } = makeMockEnv();
+      const req = new Request("http://localhost/api/ask-arc", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ question: "test" }),
+      });
+      const res = await worker.fetch(req, env);
+      expect(res.status).toBe(402);
+      expect(calls).toHaveLength(1);
+      expect(calls[0].method).toBe("warn");
+      expect(calls[0].appId).toBe("arc0btc-worker");
+      expect(calls[0].context.status).toBe(402);
+      expect(calls[0].context.method).toBe("POST");
+      expect(calls[0].context.path).toBe("/api/ask-arc");
+    });
+
+    it("emits error exactly once on a 5xx response (GET /api/feed with no FEEDS_KV → 500)", async () => {
+      // handleFeed accesses env.FEEDS_KV.get(...); without that binding it throws → 500
+      const { env, calls } = makeMockEnv();
+      const req = new Request("http://localhost/api/feed");
+      const res = await worker.fetch(req, env);
+      expect(res.status).toBe(500);
+      expect(calls).toHaveLength(1);
+      expect(calls[0].method).toBe("error");
+      expect(calls[0].appId).toBe("arc0btc-worker");
+      expect(calls[0].context.status).toBe(500);
+      expect(calls[0].context.method).toBe("GET");
+      expect(calls[0].context.path).toBe("/api/feed");
     });
   });
 });

--- a/test/endpoints.test.ts
+++ b/test/endpoints.test.ts
@@ -3,7 +3,9 @@
  */
 
 import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
 import worker from "../src/index";
+import { requestLogging, type LogsBinding } from "../src/middleware/request-logging";
 
 describe("arc0btc worker endpoints", () => {
   describe("GET /health", () => {
@@ -176,69 +178,74 @@ describe("arc0btc worker endpoints", () => {
   });
 
   describe("request logging middleware", () => {
-    // Build a mock LOGS binding that records which method was called and with what args.
-    function makeMockEnv() {
+    // Hermetic: mount the real middleware on an isolated app with deterministic
+    // routes, so behaviour is independent of the worker's actual endpoints/bindings.
+    function makeMockLogs() {
       const calls: { method: string; appId: string; msg: string; context: Record<string, unknown> }[] = [];
-      const LOGS = {
-        info: (appId: string, msg: string, context?: Record<string, unknown>) => {
-          calls.push({ method: "info", appId, msg, context: context ?? {} });
-          return Promise.resolve();
-        },
-        warn: (appId: string, msg: string, context?: Record<string, unknown>) => {
-          calls.push({ method: "warn", appId, msg, context: context ?? {} });
-          return Promise.resolve();
-        },
-        error: (appId: string, msg: string, context?: Record<string, unknown>) => {
-          calls.push({ method: "error", appId, msg, context: context ?? {} });
-          return Promise.resolve();
-        },
+      const record = (method: string) => (appId: string, msg: string, context?: Record<string, unknown>) => {
+        calls.push({ method, appId, msg, context: context ?? {} });
+        return Promise.resolve();
       };
-      return { env: { LOGS }, calls };
+      const LOGS: LogsBinding = { info: record("info"), warn: record("warn"), error: record("error") };
+      return { LOGS, calls };
     }
 
-    it("stays silent on a 2xx response (GET /health → 200)", async () => {
-      const { env, calls } = makeMockEnv();
-      const req = new Request("http://localhost/health");
-      await worker.fetch(req, env);
+    function makeApp() {
+      const app = new Hono<{ Bindings: { LOGS?: LogsBinding } }>();
+      app.use("*", requestLogging("arc0btc-worker"));
+      app.get("/ok", (c) => c.text("ok", 200));
+      app.get("/redirect", (c) => c.redirect("/ok", 302));
+      app.get("/bad", (c) => c.text("bad request", 400));
+      app.get("/boom", (c) => c.text("kaboom", 500));
+      return app;
+    }
+
+    it("stays silent on a 2xx response", async () => {
+      const app = makeApp();
+      const { LOGS, calls } = makeMockLogs();
+      const res = await app.request("/ok", {}, { LOGS });
+      expect(res.status).toBe(200);
       expect(calls).toHaveLength(0);
     });
 
-    it("stays silent on another 2xx response (GET / → 200 HTML)", async () => {
-      const { env, calls } = makeMockEnv();
-      const req = new Request("http://localhost/");
-      await worker.fetch(req, env);
+    it("stays silent on a 3xx response", async () => {
+      const app = makeApp();
+      const { LOGS, calls } = makeMockLogs();
+      const res = await app.request("/redirect", {}, { LOGS });
+      expect(res.status).toBe(302);
       expect(calls).toHaveLength(0);
     });
 
-    it("emits warn exactly once on a 4xx response (POST /api/ask-arc without payment → 402)", async () => {
-      const { env, calls } = makeMockEnv();
-      const req = new Request("http://localhost/api/ask-arc", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ question: "test" }),
-      });
-      const res = await worker.fetch(req, env);
-      expect(res.status).toBe(402);
+    it("emits warn exactly once on a 4xx response", async () => {
+      const app = makeApp();
+      const { LOGS, calls } = makeMockLogs();
+      const res = await app.request("/bad", {}, { LOGS });
+      expect(res.status).toBe(400);
       expect(calls).toHaveLength(1);
       expect(calls[0].method).toBe("warn");
       expect(calls[0].appId).toBe("arc0btc-worker");
-      expect(calls[0].context.status).toBe(402);
-      expect(calls[0].context.method).toBe("POST");
-      expect(calls[0].context.path).toBe("/api/ask-arc");
+      expect(calls[0].context.status).toBe(400);
+      expect(calls[0].context.method).toBe("GET");
+      expect(calls[0].context.path).toBe("/bad");
     });
 
-    it("emits error exactly once on a 5xx response (GET /api/feed with no FEEDS_KV → 500)", async () => {
-      // handleFeed accesses env.FEEDS_KV.get(...); without that binding it throws → 500
-      const { env, calls } = makeMockEnv();
-      const req = new Request("http://localhost/api/feed");
-      const res = await worker.fetch(req, env);
+    it("emits error exactly once on a 5xx response", async () => {
+      const app = makeApp();
+      const { LOGS, calls } = makeMockLogs();
+      const res = await app.request("/boom", {}, { LOGS });
       expect(res.status).toBe(500);
       expect(calls).toHaveLength(1);
       expect(calls[0].method).toBe("error");
       expect(calls[0].appId).toBe("arc0btc-worker");
       expect(calls[0].context.status).toBe(500);
       expect(calls[0].context.method).toBe("GET");
-      expect(calls[0].context.path).toBe("/api/feed");
+      expect(calls[0].context.path).toBe("/boom");
+    });
+
+    it("does not throw on a 4xx response when no LOGS binding is present", async () => {
+      const app = makeApp();
+      const res = await app.request("/bad", {}, {});
+      expect(res.status).toBe(400);
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes #23. The catch-all Hono request-logging middleware emitted an INFO log to worker-logs on **every** request — 4,786 INFO/7d with zero WARN/ERROR, a blanket access log that was the dominant driver (~72%) of `AppLogsDO` load. CF Workers observability already captures per-request analytics, so 2xx/3xx access logs are redundant.

This keeps the middleware + `waitUntil` fire-and-forget shape but gates emission on response status:

- `>= 500` → `logs.error(...)`
- `>= 400` (4xx) → `logs.warn(...)`
- 2xx/3xx → no log

Real problems are retained with full context (method, path, status, duration_ms, user_agent); the happy-path noise is gone.

## Tests

Added middleware gating tests in `test/endpoints.test.ts`: silent on 2xx and 3xx, WARN on 4xx, ERROR on 5xx.

## Notes

`c.executionCtx` is a getter that throws when no `ExecutionContext` is present (e.g. tests), so the `waitUntil` call is guarded with try/catch rather than optional chaining. Production behavior is unchanged.

## Gate

`bunx tsc --noEmit`, `bun test`, `bun run deploy:dry` (wrangler deploy --dry-run) — all green.

## Impact

Cuts arc0btc-worker's worker-logs volume by the 2xx share (likely >95%). Combined with the companion worker-logs PR (arc0btc/worker-logs#2), drives `AppLogsDO` from ~13.3k → ~2–3k invocations/wk.