### PR TITLE
Fix test infra (vitest dep skew), tsconfig split, and a real btoa 402 bug

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "arc0btc-worker",
@@ -25,6 +24,11 @@
         "wrangler": "^4.0.0",
       },
     },
+  },
+  "overrides": {
+    "@vitest/runner": "3.2.4",
+    "@vitest/snapshot": "3.2.4",
+    "@vitest/utils": "3.2.4",
   },
   "packages": {
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
@@ -359,9 +363,9 @@
 
     "@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
 
-    "@vitest/runner": ["@vitest/runner@2.1.9", "", { "dependencies": { "@vitest/utils": "2.1.9", "pathe": "^1.1.2" } }, "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g=="],
+    "@vitest/runner": ["@vitest/runner@3.2.4", "", { "dependencies": { "@vitest/utils": "3.2.4", "pathe": "^2.0.3", "strip-literal": "^3.0.0" } }, "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ=="],
 
-    "@vitest/snapshot": ["@vitest/snapshot@2.1.9", "", { "dependencies": { "@vitest/pretty-format": "2.1.9", "magic-string": "^0.30.12", "pathe": "^1.1.2" } }, "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ=="],
+    "@vitest/snapshot": ["@vitest/snapshot@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "magic-string": "^0.30.17", "pathe": "^2.0.3" } }, "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ=="],
 
     "@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
 
@@ -651,7 +655,7 @@
 
     "isows": ["isows@1.0.7", "", { "peerDependencies": { "ws": "*" } }, "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg=="],
 
-    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+    "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
@@ -935,6 +939,8 @@
 
     "zone-file": ["zone-file@2.0.0-beta.3", "", {}, "sha512-6tE3PSRcpN5lbTTLlkLez40WkNPc9vw/u1J2j6DBiy0jcVX48nCkWrx2EC+bWHqC2SLp069Xw4AdnYn/qp/W5g=="],
 
+    "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
     "@babel/generator/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@bitcoinerlab/secp256k1/@noble/curves": ["@noble/curves@1.9.2", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-HxngEd2XUcg9xi20JkwlLCtYwfoFw4JGkuZpT+WlsPD4gB/cxkvTD8fSsoAnphGZhFdZYKeQIPCuFlWPm1uE0g=="],
@@ -979,14 +985,6 @@
 
     "@stencil/core/@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.44.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Q2Mgwt+D8hd5FIPUuPDsvPR7Bguza6yTkJxspDGkZj7tBRn2y4KSWYuIXpftFSjBra76TbKerCV7rgFPQrn+wQ=="],
 
-    "@vitest/runner/@vitest/utils": ["@vitest/utils@2.1.9", "", { "dependencies": { "@vitest/pretty-format": "2.1.9", "loupe": "^3.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ=="],
-
-    "@vitest/runner/pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
-
-    "@vitest/snapshot/@vitest/pretty-format": ["@vitest/pretty-format@2.1.9", "", { "dependencies": { "tinyrainbow": "^1.2.0" } }, "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ=="],
-
-    "@vitest/snapshot/pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
-
     "@walletconnect/jsonrpc-ws-connection/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
     "@walletconnect/relay-auth/@noble/curves": ["@noble/curves@1.8.0", "", { "dependencies": { "@noble/hashes": "1.7.0" } }, "sha512-j84kjAbzEnQHaSIhRPUmB3/eVXu2k3dKPl2LOrR8fSOIL+89U+7lV117EWHtq/GHM3ReGHM46iRBdZfpc4HRUQ=="],
@@ -1021,8 +1019,6 @@
 
     "sharp/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
-    "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
-
     "unstorage/lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
 
     "viem/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
@@ -1030,10 +1026,6 @@
     "viem/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
     "vite-node/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
-
-    "vitest/@vitest/runner": ["@vitest/runner@3.2.4", "", { "dependencies": { "@vitest/utils": "3.2.4", "pathe": "^2.0.3", "strip-literal": "^3.0.0" } }, "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ=="],
-
-    "vitest/@vitest/snapshot": ["@vitest/snapshot@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "magic-string": "^0.30.17", "pathe": "^2.0.3" } }, "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ=="],
 
     "vitest/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
 
@@ -1054,12 +1046,6 @@
     "@stacks/network-v6/@stacks/common/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
     "@stacks/transactions-v6/@stacks/common/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
-
-    "@vitest/runner/@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@2.1.9", "", { "dependencies": { "tinyrainbow": "^1.2.0" } }, "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ=="],
-
-    "@vitest/runner/@vitest/utils/tinyrainbow": ["tinyrainbow@1.2.0", "", {}, "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ=="],
-
-    "@vitest/snapshot/@vitest/pretty-format/tinyrainbow": ["tinyrainbow@1.2.0", "", {}, "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ=="],
 
     "@walletconnect/utils/viem/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "deploy:dry": "npm run build:client && wrangler deploy --dry-run",
     "deploy:production:dry": "npm run build:client && wrangler deploy --env production --dry-run",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.client.json --noEmit"
   },
   "dependencies": {
     "@stacks/connect": "^8.2.5",
@@ -33,5 +34,10 @@
     "vite": "^7.3.1",
     "vitest": "^3.2.0",
     "wrangler": "^4.0.0"
+  },
+  "overrides": {
+    "@vitest/runner": "3.2.4",
+    "@vitest/snapshot": "3.2.4",
+    "@vitest/utils": "3.2.4"
   }
 }

--- a/src/client/components/WalletConnect.tsx
+++ b/src/client/components/WalletConnect.tsx
@@ -1,6 +1,5 @@
 import { createContext, useContext, useCallback, type ReactNode } from "react";
 import { showConnect } from "@stacks/connect";
-import { STACKS_MAINNET } from "@stacks/network";
 
 export interface WalletState {
   connected: boolean;
@@ -34,7 +33,6 @@ export function WalletProvider({ wallet, setWallet, children }: WalletProviderPr
         name: "Arc - arc0.btc",
         icon: "https://arc0.me/avatar.png",
       },
-      network: STACKS_MAINNET,
       onFinish: (data) => {
         const address = data.authResponsePayload?.profile?.stxAddress?.mainnet;
         if (address) {

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -4,7 +4,7 @@
 
 import type { Context } from "hono";
 import { findAnswer } from "./knowledge";
-import { buildPaymentRequired, verifyPayment } from "./lib/x402";
+import { buildPaymentRequired, verifyPayment, encodeBase64 } from "./lib/x402";
 
 // =============================================================================
 // Ask Arc Handler
@@ -159,7 +159,7 @@ export async function handleAskArc(c: Context): Promise<Response> {
         status: 200,
         headers: {
           "Content-Type": "application/json",
-          "payment-response": btoa(
+          "payment-response": encodeBase64(
             JSON.stringify({
               success: true,
               payer: payment.payer,

--- a/src/lib/x402.ts
+++ b/src/lib/x402.ts
@@ -48,6 +48,18 @@ export interface SettlementResponseV2 {
 }
 
 /**
+ * Unicode-safe base64 encode. `btoa` only accepts Latin1 characters and throws
+ * on anything outside it (e.g. an em-dash in a description), so encode to UTF-8
+ * bytes first.
+ */
+export function encodeBase64(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+/**
  * Build a 402 Payment Required response for research content.
  */
 export function buildPaymentRequired(
@@ -81,7 +93,7 @@ export function buildPaymentRequired(
     ],
   };
 
-  const encoded = btoa(JSON.stringify(body));
+  const encoded = encodeBase64(JSON.stringify(body));
 
   return new Response(JSON.stringify(body, null, 2), {
     status: 402,

--- a/test/endpoints.test.ts
+++ b/test/endpoints.test.ts
@@ -2,10 +2,25 @@
  * Endpoint tests for arc0btc worker
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { Hono } from "hono";
 import worker from "../src/index";
 import { requestLogging, type LogsBinding } from "../src/middleware/request-logging";
+
+// Payment verification calls the live x402 relay; mock it to a successful
+// settlement so payment-gated handlers are reachable in tests. buildPaymentRequired
+// and encodeBase64 stay real.
+vi.mock("../src/lib/x402", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/lib/x402")>();
+  return {
+    ...actual,
+    verifyPayment: vi.fn(async () => ({
+      success: true,
+      payer: "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+      txid: "0xabcd1234",
+    })),
+  };
+});
 
 describe("arc0btc worker endpoints", () => {
   describe("GET /health", () => {
@@ -25,25 +40,43 @@ describe("arc0btc worker endpoints", () => {
   });
 
   describe("GET /", () => {
-    it("returns 200 HTML landing page", async () => {
-      const req = new Request("http://localhost/", { method: "GET" });
+    it("returns the service directory as JSON for agent clients", async () => {
+      const req = new Request("http://localhost/", {
+        method: "GET",
+        headers: { "user-agent": "claude-bot/1.0", accept: "application/json" },
+      });
       const res = await worker.fetch(req);
 
       expect(res.status).toBe(200);
-      expect(res.headers.get("content-type")).toContain("text/html");
+      expect(res.headers.get("content-type")).toContain("application/json");
 
-      const html = await res.text();
-      expect(html).toContain("Arc");
-      expect(html).toContain("arc0.btc");
-      expect(html).toContain("/api/ask-arc");
+      const data = (await res.json()) as {
+        identity: { name: string; bns: string };
+        services: { endpoint: string }[];
+      };
+      expect(data.identity.name).toBe("Arc");
+      expect(data.identity.bns).toBe("arc0.btc");
+      expect(data.services.some((s) => s.endpoint === "/api/ask-arc")).toBe(true);
     });
   });
 
   describe("POST /api/ask-arc", () => {
-    // Valid payment header for tests
-    // Format: stx:{address}:{txid}:{amount}:{token}
-    const validPaymentHeader =
-      "stx:SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7:0xabcd1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab:0.005:STX";
+    // A base64-encoded x402 v2 payment payload. verifyPayment is mocked, so only
+    // its presence matters; the shape mirrors what the real client sends.
+    const validPaymentHeader = btoa(
+      JSON.stringify({
+        x402Version: 2,
+        accepted: {
+          scheme: "exact",
+          network: "stacks:1",
+          amount: "250",
+          asset: "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token",
+          payTo: "SP2GHQRCRMYY4S8PMBR49BEKX144VR437YT42SF3B",
+          maxTimeoutSeconds: 300,
+        },
+        payload: { transaction: "0xabcd1234" },
+      })
+    );
 
     it("returns 402 when payment header is missing", async () => {
       const req = new Request("http://localhost/api/ask-arc", {
@@ -64,7 +97,7 @@ describe("arc0btc worker endpoints", () => {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "x-402-payment": validPaymentHeader,
+          "payment-signature": validPaymentHeader,
         },
         body: JSON.stringify({ question: "What is tx-sender?" }),
       });
@@ -85,7 +118,7 @@ describe("arc0btc worker endpoints", () => {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "x-402-payment": validPaymentHeader,
+          "payment-signature": validPaymentHeader,
         },
         body: "invalid json",
       });
@@ -102,7 +135,7 @@ describe("arc0btc worker endpoints", () => {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "x-402-payment": validPaymentHeader,
+          "payment-signature": validPaymentHeader,
         },
         body: JSON.stringify({}),
       });
@@ -121,7 +154,7 @@ describe("arc0btc worker endpoints", () => {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "x-402-payment": validPaymentHeader,
+          "payment-signature": validPaymentHeader,
         },
         body: JSON.stringify({ question: longQuestion }),
       });
@@ -139,7 +172,7 @@ describe("arc0btc worker endpoints", () => {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "x-402-payment": validPaymentHeader,
+          "payment-signature": validPaymentHeader,
         },
         body: JSON.stringify({
           question: "What is this?",
@@ -160,7 +193,7 @@ describe("arc0btc worker endpoints", () => {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "x-402-payment": validPaymentHeader,
+          "payment-signature": validPaymentHeader,
         },
         body: JSON.stringify({
           question: "What is ERC-8004?",

--- a/tsconfig.client.json
+++ b/tsconfig.client.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "ES2022",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "moduleResolution": "bundler",
     "strict": true,
     "skipLibCheck": true,
@@ -10,8 +10,9 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "types": ["@cloudflare/workers-types"]
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", ".wrangler", "src/client"]
+  "include": ["src/client/**/*"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Pre-existing cleanup, independent of the logging change in #24. Each item below was red on `main`.

## What this fixes

**1. Test suite couldn't run (dependency skew).**
`bun.lock` hoisted `@vitest/runner@2.1.9` (with `pathe@1`) alongside `vitest@3.2.4` (needs `@vitest/runner@3.2.4` + `pathe@2`). `@cloudflare/vitest-pool-workers` loaded the 2.1.9 runner → `normalizeWindowsPath` crashed (`input.replace is not a function`) → `vitest run` reported **"no tests"**. Pinned `@vitest/runner`/`@vitest/snapshot`/`@vitest/utils` to `3.2.4` via `overrides`.

**2. Real production bug: `btoa` on the 402 path.**
`buildPaymentRequired` did `btoa(JSON.stringify(body))`, but `btoa` only accepts Latin1 — and the description `"Ask Arc — knowledge base query"` contains an em-dash. So the **402 Payment Required path threw `InvalidCharacterError` and returned 500 in production**, not just tests. Added a Unicode-safe `encodeBase64` helper (UTF-8 bytes → btoa), used for both `payment-required` and `payment-response` headers.

**3. tsconfig split.**
A single `tsconfig.json` type-checked the React SPA (`src/client`) with worker settings (`lib: ["ES2022"]` no DOM, `@cloudflare/workers-types`) → ~13 phantom errors (`window`/`document`/JSX/`HTMLInputElement`). Split into a worker `tsconfig.json` (excludes `src/client`) + `tsconfig.client.json` (DOM lib + `react-jsx`), wired to a new `typecheck` script.

**4. `@stacks/connect` v8 fix.**
`WalletConnect.tsx` passed `network` to `showConnect`, which v8 removed from `AuthOptions`. Removed it (the wallet supplies the network) and the unused `STACKS_MAINNET` import.

**5. Repaired the stale endpoint tests.**
- Use the canonical `payment-signature` header (what `Services.tsx` and the routes actually use), not the stale `x-402-payment`.
- Mock `verifyPayment` (it calls the live `x402-relay.aibtc.com`) so payment-gated handlers are reachable; `buildPaymentRequired`/`encodeBase64` stay real.
- Rewrote the obsolete `GET /` test (expected inline HTML; `/` now serves the SPA or an agent-JSON directory) to assert the agent-JSON service directory.

## Gate
`bun run typecheck` (both configs), `bun run test` (**14/14 pass**, was "no tests"), and `bun run deploy:dry` — all green.